### PR TITLE
Fixed the build-storybook script

### DIFF
--- a/templates/package.json
+++ b/templates/package.json
@@ -10,7 +10,7 @@
     "lint": "standard --verbose | snazzy",
     "lint:fix": "standard --fix",
     "storybook": "start-storybook -p 9001 -c storybook",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -c storybook",
     "test-storybook": "storyshots -c storybook",
     "build": "npm run lint && npm test && npm run dist && npm run ghpages",
     "dist": "webpack -p --config storybook/webpack.dist.config.js",


### PR DESCRIPTION
If has `build-storybook` present in `package.json` the storybook deployer using it for deploy to gh pages. See here: [storybook_to_ghpages#L25](https://github.com/kadirahq/storybook-deployer/blob/master/bin/storybook_to_ghpages#L25). 

The script `build-storybook` throw an exception if the `.storybook/` not present. 

In this case, we need to specify the folder with `-c` parameter.

Solved #33 