### PR TITLE
Fix duplicated prefix when the package name starts with 'react'

### DIFF
--- a/slushfile.js
+++ b/slushfile.js
@@ -70,8 +70,18 @@ gulp.task('default', done => {
       files.push(`!${path.join(__dirname, 'templates', 'circle.yml')}`)
     }
 
+    const isToAddReactPrefix = (
+      answers.name.indexOf('react-') === -1 ||
+      answers.name.indexOf('react-') !== 0
+    )
+
     answers.name = _.humanize(answers.name)
-    answers.slugName = 'react-' + _.slugify(answers.name)
+    answers.slugName = _.slugify(answers.name)
+
+    if (isToAddReactPrefix) {
+      answers.slugName = 'react-' + answers.slugName
+    }
+
     answers.camelName = _.camelize(answers.name)
 
     git.init({ args: '--quiet' })

--- a/templates/README.md
+++ b/templates/README.md
@@ -14,7 +14,7 @@ $ npm install @personare/<%= slugName %> --save
 
 ## Usage
 ```js
-import <%= camelName %> from '@personare/<%= camelName %>';
+import <%= camelName %> from '@personare/<%= slugName %>';
 
 <<%= camelName %> />
 ```


### PR DESCRIPTION
Proposed changes:

- Verify has prefix before concat;
- Fixed `README.md` import example

Fixed #35 